### PR TITLE
allow by pass prepareResources

### DIFF
--- a/dist/middleware/createApiMiddleware.js
+++ b/dist/middleware/createApiMiddleware.js
@@ -127,7 +127,16 @@ function createMiddleware(host, defaultHeaders) {
     resources.forEach(function (resource) {
       var resourceAttributes = resource.attributes;
 
-      if (resourceAttributes && resourceAttributes.meta && resourceAttributes.meta.invocation) {
+      var _meta = {};
+
+      // normalize of meta data
+      if (resource.meta) {
+        _meta = resource.meta;
+      } else if (resourceAttributes && resourceAttributes.meta) {
+        _meta = resourceAttributes.meta;
+      }
+
+      if (_meta.invocation) {
         urlParts = [].concat((0, _toConsumableArray3.default)(urlParts), ['/', (0, _humps.decamelize)(resourceAttributes.meta.invocation)]);
         delete resourceAttributes.meta;
       } else if (resource.type) {

--- a/dist/modules/api.js
+++ b/dist/modules/api.js
@@ -51,6 +51,11 @@ var request = function request(method, resources, _ref) {
   };
 };
 
+var prepareResourcesByPass = function prepareResourcesByPass(resources) {
+  if (Array.isArray(resources)) return resources;
+  return [resources];
+};
+
 var prepareResources = function prepareResources(resources) {
   if (Array.isArray(resources)) return resources.map(function (resource) {
     return (0, _serializers.serialize)(resource);
@@ -72,7 +77,10 @@ var read = exports.read = function read(resources) {
 var write = exports.write = function write(resources) {
   var payload = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
-  return request(dataResource(resources).hasOwnProperty('id') ? PATCH : POST, prepareResources(resources), payload);
+  // bypassPrepareResources flag allows you to by pass prepareResources
+  var _resources = resources.meta && resources.meta.bypassPrepareResources ? prepareResourcesByPass(resources) : prepareResources(resources);
+
+  return request(dataResource(resources).hasOwnProperty('id') ? PATCH : POST, _resources, payload);
 };
 
 var remove = exports.remove = function remove(resources) {

--- a/src/middleware/createApiMiddleware.js
+++ b/src/middleware/createApiMiddleware.js
@@ -48,7 +48,16 @@ function createMiddleware(host, defaultHeaders) {
     resources.forEach((resource) => {
       const resourceAttributes = resource.attributes
 
-      if (resourceAttributes && resourceAttributes.meta && resourceAttributes.meta.invocation) {
+      var _meta = {}
+
+      // normalize of meta data
+      if(resource.meta) {
+        _meta = resource.meta
+      } else if(resourceAttributes && resourceAttributes.meta) {
+        _meta = resourceAttributes.meta
+      }
+
+      if (_meta.invocation) {
         urlParts = [...urlParts, '/', decamelize(resourceAttributes.meta.invocation)]
         delete resourceAttributes.meta
       } else if (resource.type){

--- a/src/modules/api.js
+++ b/src/modules/api.js
@@ -18,6 +18,11 @@ const request = (method, resources, { meta = {}, ...payload }) => {
   };
 };
 
+const prepareResourcesByPass = (resources) => {
+  if (Array.isArray(resources)) return resources
+  return [resources];
+};
+
 const prepareResources = (resources) => {
   if (Array.isArray(resources)) return resources.map((resource) => serialize(resource));
   return [serialize(resources)];
@@ -33,7 +38,10 @@ export const read = (resources, payload = {}) => {
 };
 
 export const write = (resources, payload = {}) => {
-  return request(dataResource(resources).hasOwnProperty('id') ? PATCH : POST, prepareResources(resources), payload);
+  // bypassPrepareResources flag allows you to by pass prepareResources
+  const _resources  = resources.meta && resources.meta.bypassPrepareResources ? prepareResourcesByPass(resources) : prepareResources(resources)
+
+  return request(dataResource(resources).hasOwnProperty('id') ? PATCH : POST, _resources, payload);
 };
 
 export const remove = (resources, payload = {}) => {


### PR DESCRIPTION
Allow by pass the middleware "prepareResources" function

We have a use case where one of the json api is expecting a "non json api spec" and at the end, I need to by pass the prepareResources function and prepare the payload myself. 