### PR TITLE
Add a custom check for _dirty properties.  _dirty objects are not ove…

### DIFF
--- a/dist/modules/api.js
+++ b/dist/modules/api.js
@@ -25,7 +25,7 @@ var _objectWithoutProperties2 = require('babel-runtime/helpers/objectWithoutProp
 
 var _objectWithoutProperties3 = _interopRequireDefault(_objectWithoutProperties2);
 
-var _humps2 = require('humps');
+var _humps = require('humps');
 
 var _serializers = require('../serializers');
 
@@ -134,15 +134,15 @@ function receiveReducer(state, _ref2) {
     // back to localStorage and deletes the local modifications.
 
     // if the resource exists on the nextState
-    if (nextState[_humps.camelize(resource.type)] && nextState[_humps.camelize(resource.type)][resource.id]) {
+    if (nextState[(0, _humps.camelize)(resource.type)] && nextState[(0, _humps.camelize)(resource.type)][resource.id]) {
       // and the resource is _dirty (it came from localStorage)
-      if (nextState[_humps.camelize(resource.type)][resource.id].attributes._dirty) {
+      if (nextState[(0, _humps.camelize)(resource.type)][resource.id].attributes._dirty) {
         // then pass the current accumulator with no changes
         return nextState;
       }
     }
 
-    return (0, _extends5.default)({}, nextState, (0, _defineProperty3.default)({}, (0, _humps2.camelize)(resource.type), (0, _extends5.default)({}, nextState[(0, _humps2.camelize)(resource.type)], (0, _defineProperty3.default)({}, resource.id, method === DELETE ? undefined : resource))));
+    return (0, _extends5.default)({}, nextState, (0, _defineProperty3.default)({}, (0, _humps.camelize)(resource.type), (0, _extends5.default)({}, nextState[(0, _humps.camelize)(resource.type)], (0, _defineProperty3.default)({}, resource.id, method === DELETE ? undefined : resource))));
   }, state);
 }
 

--- a/dist/modules/api.js
+++ b/dist/modules/api.js
@@ -25,7 +25,7 @@ var _objectWithoutProperties2 = require('babel-runtime/helpers/objectWithoutProp
 
 var _objectWithoutProperties3 = _interopRequireDefault(_objectWithoutProperties2);
 
-var _humps = require('humps');
+var _humps2 = require('humps');
 
 var _serializers = require('../serializers');
 
@@ -127,7 +127,22 @@ function receiveReducer(state, _ref2) {
       resources = _ref2.resources;
 
   return resources.reduce(function (nextState, resource) {
-    return (0, _extends5.default)({}, nextState, (0, _defineProperty3.default)({}, (0, _humps.camelize)(resource.type), (0, _extends5.default)({}, nextState[(0, _humps.camelize)(resource.type)], (0, _defineProperty3.default)({}, resource.id, method === DELETE ? undefined : resource))));
+
+    // dirty state checking, if an entity is marked _dirty we're delegating to localStorage as
+    // the source of truth on the client.  The local values are reflected in the in-memory api
+    // wing of our state.  Therefore we do NOT want to overwrite these values as they get projected
+    // back to localStorage and deletes the local modifications.
+
+    // if the resource exists on the nextState
+    if (nextState[_humps.camelize(resource.type)] && nextState[_humps.camelize(resource.type)][resource.id]) {
+      // and the resource is _dirty (it came from localStorage)
+      if (nextState[_humps.camelize(resource.type)][resource.id].attributes._dirty) {
+        // then pass the current accumulator with no changes
+        return nextState;
+      }
+    }
+
+    return (0, _extends5.default)({}, nextState, (0, _defineProperty3.default)({}, (0, _humps2.camelize)(resource.type), (0, _extends5.default)({}, nextState[(0, _humps2.camelize)(resource.type)], (0, _defineProperty3.default)({}, resource.id, method === DELETE ? undefined : resource))));
   }, state);
 }
 

--- a/src/modules/api.js
+++ b/src/modules/api.js
@@ -84,6 +84,21 @@ function getInitialState() {
 
 function receiveReducer(state, { method, resources }) {
   return resources.reduce((nextState, resource) => {
+
+    // dirty state checking, if an entity is marked _dirty we're delegating to localStorage as
+    // the source of truth on the client.  The local values are reflected in the in-memory api
+    // wing of our state.  Therefore we do NOT want to overwrite these values as they get projected
+    // back to localStorage and deletes the local modifications.
+
+    // if the resource exists on the nextState
+    if(nextState[_humps.camelize(resource.type)] && nextState[_humps.camelize(resource.type)][resource.id]){
+      // and the resource is _dirty (it came from localStorage)
+      if(nextState[_humps.camelize(resource.type)][resource.id].attributes._dirty) {
+        // then pass the current accumulator with no changes
+        return nextState;
+      }
+    }
+
     return {
       ...nextState,
       [camelize(resource.type)]: {

--- a/src/modules/api.js
+++ b/src/modules/api.js
@@ -91,9 +91,9 @@ function receiveReducer(state, { method, resources }) {
     // back to localStorage and deletes the local modifications.
 
     // if the resource exists on the nextState
-    if(nextState[_humps.camelize(resource.type)] && nextState[_humps.camelize(resource.type)][resource.id]){
+    if(nextState[camelize(resource.type)] && nextState[camelize(resource.type)][resource.id]){
       // and the resource is _dirty (it came from localStorage)
-      if(nextState[_humps.camelize(resource.type)][resource.id].attributes._dirty) {
+      if(nextState[camelize(resource.type)][resource.id].attributes._dirty) {
         // then pass the current accumulator with no changes
         return nextState;
       }


### PR DESCRIPTION
This PR adds a check for entities marked _dirty.  This means the entities which originate locally will not be overwritten from api requests.  In a sense this is a delegation of the source of truth from remote to local.  See comments in code for more information.